### PR TITLE
Score box timing; headline newlines bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To see the same static HTML, CSS, JS files that are served on GH Pages, you need
 
 ### Models and TS Types
 
-If the models in the [https://github.com/xblbaseball/stats](stats repo) have changed, collect the new JSON schemas and rebuild our TS type interfaces.
+If the models in the [stats repo](https://github.com/xblbaseball/stats) have changed, collect the new JSON schemas and rebuild our TS type interfaces.
 
 ```sh
 # download new schemas and turn the JSON schemas into TS interfaces

--- a/src/components/headlines.module.css
+++ b/src/components/headlines.module.css
@@ -1,8 +1,12 @@
 .container {
   min-width: 100%;
   padding-top: 8px;
-  padding-left: 8px;
+  border-left: 2px solid white;
+}
+
+.innerContainer {
   overflow: hidden;
+  padding-left: 8px;
 }
 
 .title {

--- a/src/components/headlines.tsx
+++ b/src/components/headlines.tsx
@@ -1,5 +1,5 @@
 import _ from "lodash";
-import { useContext, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import { SettingsContext } from "@/store/settings.context";
 
 import styles from "./headlines.module.css";
@@ -8,21 +8,25 @@ import useInterval from "@/utils/useInterval";
 export default function Headlines() {
   const { headlines } = useContext(SettingsContext);
   const [headlineIndex, setHeadlineIndex] = useState(0);
+  const [lines, setLines] = useState([[""], [""]]);
 
   const approxMaxTitleCharLength = 100;
 
-  let lines = [[""], [""]];
+  useEffect(() => {
+    const oneOrMoreNewlines = new RegExp("\n+")
+    if (_.isString(headlines) && headlines.length > 0) {
+      const newLines = headlines
+        .trim()
+        .split(oneOrMoreNewlines)
+        .map(line => line.trim().split("|")
+          .map(side => side.trim())
+        );
 
-  if (_.isString(headlines) && headlines.length > 0) {
-    lines = headlines
-      .trim()
-      .split("\n")
-      .map(line => line.trim().split("|")
-        .map(side => side.trim())
-      );
-  }
+      setLines(newLines);
+    }
+  }, [headlines]);
 
-  // make sure the horizontal scrolling interval matches
+  // matches the interval in styles/scrolls.css/.headlines-scroll
   const headlineSwapInterval = 30000;
 
   useInterval(() => {

--- a/src/components/headlines.tsx
+++ b/src/components/headlines.tsx
@@ -13,7 +13,8 @@ export default function Headlines() {
   const approxMaxTitleCharLength = 100;
 
   useEffect(() => {
-    const oneOrMoreNewlines = new RegExp("\n+")
+    const oneOrMoreNewlines = new RegExp("\n+");
+
     if (_.isString(headlines) && headlines.length > 0) {
       const newLines = headlines
         .trim()

--- a/src/components/headlines.tsx
+++ b/src/components/headlines.tsx
@@ -11,7 +11,7 @@ export default function Headlines() {
 
   const approxMaxTitleCharLength = 100;
 
-  let lines = [["-"], ["-"]];
+  let lines = [[""], [""]];
 
   if (_.isString(headlines) && headlines.length > 0) {
     lines = headlines

--- a/src/components/headlines.tsx
+++ b/src/components/headlines.tsx
@@ -39,10 +39,12 @@ export default function Headlines() {
 
   const needToScrollText = body.length > approxMaxTitleCharLength;
 
-  return <div className={`flex column headlines-fade ${styles.container}`}>
-    <div className={styles.title}>{title}</div>
-    <div className={needToScrollText ? styles.fade : undefined}>
-      <div className={`${needToScrollText ? "headlines-scroll" : undefined} ${styles.content}`}>{body}</div>
+  return <div className={`flex column ${styles.container}`}>
+    <div className={`headlines-fade ${styles.innerContainer}`}>
+      <div className={styles.title}>{title}</div>
+      <div className={needToScrollText ? styles.fade : undefined}>
+        <div className={`${needToScrollText ? "headlines-scroll" : undefined} ${styles.content}`}>{body}</div>
+      </div>
     </div>
   </div>
 }

--- a/src/components/scores-plus.module.css
+++ b/src/components/scores-plus.module.css
@@ -7,7 +7,7 @@
   height: 100%;
   margin: 4px 0px;
   border-left: 2px solid white;
-  border-right: 2px solid white;
+
 }
 
 .content {

--- a/src/components/scores-plus.tsx
+++ b/src/components/scores-plus.tsx
@@ -210,38 +210,39 @@ export default function ScoresPlus() {
     setGameIndex((gameIndex + 1) % recentGames.length);
   }, delay);
 
+  // we have to keep the divs with .scores-plus-fade alive in the DOM all the time, otherwise the score box fade in/out animation and the interval above will go out of sync
   return <div
     className={`flex column space-around ${styles.container}`}
     style={{ display: recentGames.length === 0 ? "hidden" : "block" }}
   >
     <div className={`flex column space-around ${recentGames.length > 0 && styles.innerContainer}`}>
       <div className="scores-plus-fade">
-        {
-          recentGames.length > 0 &&
-          <div className={styles.content}>
-            <TopLine
-              awayTeam={recentGames[gameIndex].away_team}
-              homeTeam={recentGames[gameIndex].home_team}
-              awayScore={recentGames[gameIndex].away_score}
-              homeScore={recentGames[gameIndex].home_score}
-              innings={recentGames[gameIndex].innings}
-            />
-          </div>
-        }
+        <div
+          className={styles.content}
+          style={{ display: recentGames.length > 0 ? 'block' : 'none' }}
+        >
+          <TopLine
+            awayTeam={_.get(recentGames[gameIndex], ['away_team'], "")}
+            homeTeam={_.get(recentGames[gameIndex], ['home_team'], "")}
+            awayScore={_.get(recentGames[gameIndex], ['away_score'], 0)}
+            homeScore={_.get(recentGames[gameIndex], ['home_score'], 0)}
+            innings={_.get(recentGames[gameIndex], ['innings'], 0)}
+          />
+        </div>
       </div>
       <div className="scores-plus-fade">
-        {
-          recentGames.length > 0 &&
-          <div className={styles.content}>
-            <BottomLine
-              awayTeam={recentGames[gameIndex].away_team}
-              homeTeam={recentGames[gameIndex].home_team}
-              week={recentGames[gameIndex].week as string}
-              round={recentGames[gameIndex].round as string}
-              league={recentGames[gameIndex].league}
-            />
-          </div>
-        }
+        <div
+          className={styles.content}
+          style={{ display: recentGames.length > 0 ? 'block' : 'none' }}
+        >
+          <BottomLine
+            awayTeam={_.get(recentGames[gameIndex], ['away_team'], "")}
+            homeTeam={_.get(recentGames[gameIndex], ['home_team'], "")}
+            week={_.get(recentGames[gameIndex], ['week'], null) as string}
+            round={_.get(recentGames[gameIndex], ['round'], null) as string}
+            league={_.get(recentGames[gameIndex], ['league'], "")}
+          />
+        </div>
       </div>
     </div>
   </div>

--- a/src/components/scores-plus.tsx
+++ b/src/components/scores-plus.tsx
@@ -200,6 +200,7 @@ export default function ScoresPlus() {
       return ret;
     }
     setRecentGames(getRecentGames());
+    setGameIndex(0);
   }, [maxBoxScores, statsStore]);
 
   // matches the interval in _document.tsx/Head/style
@@ -209,30 +210,38 @@ export default function ScoresPlus() {
     setGameIndex((gameIndex + 1) % recentGames.length);
   }, delay);
 
-  if (recentGames.length === 0) {
-    // no scores to show!
-    return <div className={"border-left"}></div>;
-  }
-
-  return <div className={`flex column space-around ${styles.container}`}>
-    <div className={`flex column space-around ${styles.innerContainer}`}>
-      <div className={`${recentGames.length > 0 && "scores-plus-fade"} ${styles.content}`}>
-        <TopLine
-          awayTeam={recentGames[gameIndex].away_team}
-          homeTeam={recentGames[gameIndex].home_team}
-          awayScore={recentGames[gameIndex].away_score}
-          homeScore={recentGames[gameIndex].home_score}
-          innings={recentGames[gameIndex].innings}
-        />
+  return <div
+    className={`flex column space-around ${styles.container}`}
+    style={{ display: recentGames.length === 0 ? "hidden" : "block" }}
+  >
+    <div className={`flex column space-around ${recentGames.length > 0 && styles.innerContainer}`}>
+      <div className="scores-plus-fade">
+        {
+          recentGames.length > 0 &&
+          <div className={styles.content}>
+            <TopLine
+              awayTeam={recentGames[gameIndex].away_team}
+              homeTeam={recentGames[gameIndex].home_team}
+              awayScore={recentGames[gameIndex].away_score}
+              homeScore={recentGames[gameIndex].home_score}
+              innings={recentGames[gameIndex].innings}
+            />
+          </div>
+        }
       </div>
-      <div className={`${recentGames.length > 0 && "scores-plus-fade"} ${styles.content}`}>
-        <BottomLine
-          awayTeam={recentGames[gameIndex].away_team}
-          homeTeam={recentGames[gameIndex].home_team}
-          week={recentGames[gameIndex].week as string}
-          round={recentGames[gameIndex].round as string}
-          league={recentGames[gameIndex].league}
-        />
+      <div className="scores-plus-fade">
+        {
+          recentGames.length > 0 &&
+          <div className={styles.content}>
+            <BottomLine
+              awayTeam={recentGames[gameIndex].away_team}
+              homeTeam={recentGames[gameIndex].home_team}
+              week={recentGames[gameIndex].week as string}
+              round={recentGames[gameIndex].round as string}
+              league={recentGames[gameIndex].league}
+            />
+          </div>
+        }
       </div>
     </div>
   </div>

--- a/src/components/scores-plus.tsx
+++ b/src/components/scores-plus.tsx
@@ -127,7 +127,7 @@ function BottomLine(
     winsAndLosses = `${awayTeamAbbrev} ${awayTeamRecord} ${homeTeamAbbrev} ${homeTeamRecord}.`
   }
 
-  const fullLine = `${weekOrRound} ${winsAndLosses}`.trim();
+  const fullLine = `${league} ${weekOrRound} ${winsAndLosses}`.trim();
 
   return <div>{fullLine}</div>
 }

--- a/src/components/settings.tsx
+++ b/src/components/settings.tsx
@@ -683,7 +683,7 @@ export default function Settings() {
 
     <Input
       value={settingsStore.maxBoxScores || ""}
-      onChange={(games) => updateSetting(['maxBoxScores'], parseInt(games as string))}
+      onChange={(num) => updateSetting(['maxBoxScores'], parseInt(num as string) || 0)}
     >
       How many box scores should we rotate through? This number should be divisible by 3.
     </Input>

--- a/src/components/settings.tsx
+++ b/src/components/settings.tsx
@@ -685,7 +685,7 @@ export default function Settings() {
       value={settingsStore.maxBoxScores || ""}
       onChange={(games) => updateSetting(['maxBoxScores'], parseInt(games as string))}
     >
-      How many box scores should we rotate through? This number should be divisible by 3. If you change this, you&apos;ll need to reload the page for the changes to take effect.
+      How many box scores should we rotate through? This number should be divisible by 3.
     </Input>
 
     <h3>Current Settings</h3>

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -3,7 +3,40 @@ import { Html, Head, Main, NextScript } from "next/document";
 export default function Document() {
   return (
     <Html lang="en">
-      <Head />
+      <Head>
+        <style>
+          {`
+            /* inline scores-plus animation CSS to guarantee it's there when scores need to rotate */
+
+            /* interval matches the interval for swapping out scores in components/scores-plus.tsx */
+            .scores-plus-fade {
+              animation: fade 15s ease 0s infinite forwards;
+            }
+
+            @keyframes fade {
+              0% {
+                transform: translateY(30px);
+                opacity: 0;
+              }
+
+              5% {
+                transform: translateY(0px);
+                opacity: 1;
+              }
+
+              95% {
+                transform: translateY(0px);
+                opacity: 1;
+              }
+
+              100% {
+                transform: translateY(-30px);
+                opacity: 0;
+              }
+            }
+          `}
+        </style>
+      </Head>
       <body>
         <Main />
         <NextScript />

--- a/src/store/settings.reducer.ts
+++ b/src/store/settings.reducer.ts
@@ -138,7 +138,7 @@ export const initialState: SettingsStore = {
     fifth: "opphr9",
     sixth: "whip",
   },
-  headlines: "",
+  headlines: `League News | You're watching season ${currentSeason} XBL baseball`,
   maxBoxScores: 24
 };
 

--- a/src/styles/scrolls.css
+++ b/src/styles/scrolls.css
@@ -1,8 +1,3 @@
-.scores-plus-fade {
-  /* interval matches the interval for swapping out scores in components/scores-plus.tsx */
-  animation: fade 15s ease 0s infinite forwards;
-}
-
 .headlines-fade {
   animation: fade 30s ease 0s infinite forwards;
 }
@@ -46,28 +41,6 @@
 
 .vertical-scroll-60 {
   animation: vertical-scroll-60 var(--ticker-cycle) ease 0s infinite forwards;
-}
-
-@keyframes fade {
-  0% {
-    transform: translateY(30px);
-    opacity: 0;
-  }
-
-  5% {
-    transform: translateY(0px);
-    opacity: 1;
-  }
-
-  95% {
-    transform: translateY(0px);
-    opacity: 1;
-  }
-
-  100% {
-    transform: translateY(-30px);
-    opacity: 0;
-  }
 }
 
 @keyframes headlinesScroll {


### PR DESCRIPTION
Attempts to fix desyncs between when the scores in the score box switch out and when the scores fade in and out. This problem was first noticed in spliff's stream - scores would fade out and back in, _then_ switch to the next game.

* Inlines CSS for the fade in/out animation
* Does things the react way to figure out which games we should be showing in the score box

Also fixes a bug where users put multiple newlines between headlines. Now they can space out headlines by as many lines as they want