### PR TITLE
always show team record regardless of the league logo being shown

### DIFF
--- a/src/components/settings.tsx
+++ b/src/components/settings.tsx
@@ -156,7 +156,7 @@ export default function Settings() {
         }
       }}
     >
-      Which league is playing? Controls the logo in the top left and some scores and records.
+      Choose a league logo to show.
     </Dropdown>
 
     <h3>Playoffs</h3>

--- a/src/store/settings.reducer.ts
+++ b/src/store/settings.reducer.ts
@@ -18,7 +18,7 @@ export interface SettingsStore {
     AAA: boolean;
     AA: boolean;
   };
-  /** what league are the players in. controls the logo in the top left and stats */
+  /** what league are the players in. controls the logo in the top left */
   league: League;
   /** what season are we in */
   season: number;


### PR DESCRIPTION
Before, we used the league logo as the source of truth for what league the players are in for sidebar stats. Now, we just look at the stats and figure out what league they're in. The stats / records in the left bar should be correct regardless of the logo being shown.