### PR TITLE
add randomized headlines

### DIFF
--- a/src/components/headlines.tsx
+++ b/src/components/headlines.tsx
@@ -66,7 +66,7 @@ export default function Headlines() {
     const halfway = Math.floor(lines.length / 2)
     if (historyCopy.length > Math.max(1, halfway)) {
       // it's a problem if the history grows too big
-      // keep it at a size where the headlines feel "random"
+      // keep it at a size where the headlines feel "random" without repeating the same couple headlines over and over
       historyCopy = historyCopy.slice(-halfway);
     }
 

--- a/src/components/headlines.tsx
+++ b/src/components/headlines.tsx
@@ -1,17 +1,32 @@
 import _ from "lodash";
-import { useContext, useEffect, useState } from "react";
+import { useContext, useEffect, useRef, useState } from "react";
 import { SettingsContext } from "@/store/settings.context";
 
 import styles from "./headlines.module.css";
 
-export default function Headlines() {
-  const { headlines } = useContext(SettingsContext);
-  const [headlineIndex, setHeadlineIndex] = useState(0);
-  const [lines, setLines] = useState([[""], [""]]);
+/**
+ * Get a random integer in [0,max). Function from: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/random#try_it
+ */
+function getRandomInt(max: number) {
+  return Math.floor(Math.random() * max);
+}
 
-  const approxMaxHeadlineCharLength = 100;
+export default function Headlines() {
+  const { headlines, randomHeadlines } = useContext(SettingsContext);
+  // the index of the headline currently being shown
+  const [headlineIndex, setHeadlineIndex] = useState(0);
+  // a list of headlines in the form of ["title", "body"]
+  const [lines, setLines] = useState([[""], [""]]);
+  // what actually gets rendered
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+  // used to avoid repeating headlines too quickly when randomized
+  const [history, setHistory] = useState([]);
+
+  const approxMaxHeadlineCharLengthNoScroll = 100;
 
   useEffect(() => {
+    console.log('hi')
     const oneOrMoreNewlines = new RegExp("\n+");
 
     if (_.isString(headlines) && headlines.length > 0) {
@@ -23,19 +38,52 @@ export default function Headlines() {
         );
 
       setLines(newLines);
+
+      if (newLines.length > 0) {
+        const firstTitle = _.get(newLines, [headlineIndex, 0], "");
+        const firstBody = _.get(newLines, [headlineIndex, 1], "");
+        setTitle(firstTitle);
+        setBody(firstBody);
+      }
     }
   }, [headlines]);
 
-  const title = _.get(lines, [headlineIndex, 0], "");
-  const body = _.get(lines, [headlineIndex, 1], "");
+  /** called when a headline fades out */
+  const handleAnimationIteration = () => {
+    let nextIndex = (headlineIndex + 1) % lines.length;
 
-  const needToScrollText = body.length > approxMaxHeadlineCharLength;
+    if (randomHeadlines) {
+      nextIndex = getRandomInt(lines.length);
+      if (lines.length > 3) {
+        // only try to avoid repeats if there are 4 or more headlines
+        while (_.includes(history, nextIndex)) {
+          nextIndex = getRandomInt(lines.length);
+        }
+      }
+    }
+
+    // track the last few headlines we showed
+    const historyCopy = _.clone(history);
+    historyCopy.push(nextIndex);
+    if (historyCopy.length > Math.max(2, Math.floor(lines.length / 2))) {
+      // keep track of a list of lines.length / 2 headlines we've shown to avoid repeats
+      historyCopy.shift();
+    }
+
+    const thisTitle = _.get(lines, [nextIndex, 0], "");
+    const thisBody = _.get(lines, [nextIndex, 1], "");
+
+    setTitle(thisTitle)
+    setBody(thisBody);
+    setHeadlineIndex(nextIndex);
+    setHistory(historyCopy);
+  }
+
+  const needToScrollText = body.length > approxMaxHeadlineCharLengthNoScroll;
 
   return <div className={`flex column ${styles.container}`}>
     <div className={`headlines-fade ${styles.innerContainer}`}
-      onAnimationIteration={() => {
-        setHeadlineIndex((headlineIndex + 1) % lines.length);
-      }}>
+      onAnimationIteration={handleAnimationIteration}>
       <div className={styles.title}>{title}</div>
       <div className={needToScrollText ? styles.fade : undefined}>
         <div className={`${needToScrollText ? "headlines-scroll" : undefined} ${styles.content}`}>{body}</div>

--- a/src/components/headlines.tsx
+++ b/src/components/headlines.tsx
@@ -45,6 +45,7 @@ export default function Headlines() {
         setBody(firstBody);
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [headlines]);
 
   /** called when a headline fades out */

--- a/src/components/headlines.tsx
+++ b/src/components/headlines.tsx
@@ -1,5 +1,5 @@
 import _ from "lodash";
-import { useContext, useEffect, useRef, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import { SettingsContext } from "@/store/settings.context";
 
 import styles from "./headlines.module.css";

--- a/src/components/headlines.tsx
+++ b/src/components/headlines.tsx
@@ -26,7 +26,6 @@ export default function Headlines() {
   const approxMaxHeadlineCharLengthNoScroll = 100;
 
   useEffect(() => {
-    console.log('hi')
     const oneOrMoreNewlines = new RegExp("\n+");
 
     if (_.isString(headlines) && headlines.length > 0) {

--- a/src/components/headlines.tsx
+++ b/src/components/headlines.tsx
@@ -52,22 +52,21 @@ export default function Headlines() {
   const handleAnimationIteration = () => {
     let nextIndex = (headlineIndex + 1) % lines.length;
 
-    if (randomHeadlines) {
+    if (randomHeadlines && lines.length > 2) {
+      // only randomize when there are at least 3 headlines
       nextIndex = getRandomInt(lines.length);
-      if (lines.length > 3) {
-        // only try to avoid repeats if there are 4 or more headlines
-        while (_.includes(history, nextIndex)) {
-          nextIndex = getRandomInt(lines.length);
-        }
+      while (_.includes(history, nextIndex)) {
+        nextIndex = getRandomInt(lines.length);
       }
     }
 
-    // track the last few headlines we showed
+    // track the last few headlines we showed to avoid repeats when randomization is on
     let historyCopy = _.clone(history);
     historyCopy.push(nextIndex);
     const halfway = Math.floor(lines.length / 2)
-    if (historyCopy.length > Math.max(2, halfway)) {
-      // keep track of a list of lines.length / 2 headlines we've shown to avoid repeats
+    if (historyCopy.length > Math.max(1, halfway)) {
+      // it's a problem if the history grows too big
+      // keep it at a size where the headlines feel "random"
       historyCopy = historyCopy.slice(-halfway);
     }
 

--- a/src/components/headlines.tsx
+++ b/src/components/headlines.tsx
@@ -63,11 +63,12 @@ export default function Headlines() {
     }
 
     // track the last few headlines we showed
-    const historyCopy = _.clone(history);
+    let historyCopy = _.clone(history);
     historyCopy.push(nextIndex);
-    if (historyCopy.length > Math.max(2, Math.floor(lines.length / 2))) {
+    const halfway = Math.floor(lines.length / 2)
+    if (historyCopy.length > Math.max(2, halfway)) {
       // keep track of a list of lines.length / 2 headlines we've shown to avoid repeats
-      historyCopy.shift();
+      historyCopy = historyCopy.slice(-halfway);
     }
 
     const thisTitle = _.get(lines, [nextIndex, 0], "");

--- a/src/components/settings.tsx
+++ b/src/components/settings.tsx
@@ -680,6 +680,13 @@ export default function Settings() {
       Headlines
     </TextArea>
 
+    <Checkbox
+      checked={settingsStore.randomHeadlines}
+      onChange={(doRandom) => updateSetting(["randomHeadlines"], doRandom)}
+    >
+      Randomize the order in which headlines are shown. If there are 4 or more headlines, we will avoid repeating the same headline twice in a row.
+    </Checkbox>
+
     <h3>Bottom Bar</h3>
 
     <Input

--- a/src/components/settings.tsx
+++ b/src/components/settings.tsx
@@ -684,7 +684,7 @@ export default function Settings() {
       checked={settingsStore.randomHeadlines}
       onChange={(doRandom) => updateSetting(["randomHeadlines"], doRandom)}
     >
-      Randomize the order in which headlines are shown. If there are 4 or more headlines, we will avoid repeating the same headline twice in a row.
+      Randomize the order in which headlines are shown. This checkbox does nothing unless there are 3 or more headlines.
     </Checkbox>
 
     <h3>Bottom Bar</h3>

--- a/src/store/settings.reducer.ts
+++ b/src/store/settings.reducer.ts
@@ -86,6 +86,8 @@ export interface SettingsStore {
   };
   /** marquees in the format of "AAA News | This is text I want to scroll" */
   headlines: string;
+  /** if true, show headlines in a random order */
+  randomHeadlines: boolean;
   /** how many games to rotate through the box scores */
   maxBoxScores: number;
 }
@@ -139,6 +141,7 @@ export const initialState: SettingsStore = {
     sixth: "whip",
   },
   headlines: `Broadcast News | You're watching season ${currentSeason} XBL baseball!`,
+  randomHeadlines: false,
   maxBoxScores: 24
 };
 


### PR DESCRIPTION
Addresses #48 

Adds:
* checkbox that allows a caster to randomize the order in which headlines are shown

If there are 3 or fewer headlines, we just get the next headline at random. If there are 4 or more headlines, there is logic to avoid showing the same headline again too quickly. Here's how it works:

1. If there are $N$ headlines, track a history of length $N/2$
2. When it's time to render a new headline, select one at random
3. If the headline appears in the history,  repeatedly select a new headline at random until one is found that is not in the history.
4. Add the headline to the history.

To test:
* Load ticker
* Write headlines
* Check the new checkbox
* Confirm that headlines aren't repeated one after the other when there are 4 or more. Change the speed of scrolling animations in `scrolls.css` -> `.headlines-fade` and `.headlines-scroll` to run through them faster.
* Confirm that editing headlines + checking and unchecking the new checkbox don't cause any unexpected behaviors